### PR TITLE
feat(journald): allow tedge to execute journalctl commands

### DIFF
--- a/tedge-log-provider/nfpm.yaml
+++ b/tedge-log-provider/nfpm.yaml
@@ -22,6 +22,9 @@ apk:
 depends:
   - jq
 
+scripts:
+  postinstall: ./tedge-log-provider/packaging/postinst
+
 contents:
 
 # workflows

--- a/tedge-log-provider/packaging/postinst
+++ b/tedge-log-provider/packaging/postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+add_user_to_group() {
+    user="$1"
+    group="$2"
+
+    if ! id -nG "$user" | tr ' ' '\n' | grep -q "^$group$"; then
+        usermod -a -G "$group" "$user" || echo "WARNING: Failed to add user ($user) to group ($group)"
+    else
+        echo "$user is already in the $group group" >&2
+    fi
+}
+
+if command -V journalctl >/dev/null 2>&1; then
+    # Allow user to run journalctl commands without root access
+    add_user_to_group tedge adm
+fi


### PR DESCRIPTION
Add the `tedge` user to the `adm` group so that the user can run journalctl commands without using sudo